### PR TITLE
use GOVEE_ROOT_URL

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,11 @@ fn get_govee_api_key() -> String {
     std::env::var("GOVEE_API_KEY").expect("GOVEE_API_KEY must be set.")
 }
 
+pub fn get_goove_root_url() -> String {
+    dotenv().ok();
+    std::env::var("GOVEE_ROOT_URL").expect("GOVEE_ROOT_URL must be set.")
+}
+
 fn tv_light_setup(command: &str) -> PayloadBody {
     let goove_api_device =
         std::env::var("GOVEE_DEVICE_ID_TV_LIGHT").expect("GOVEE_DEVICE_ID_TV_LIGHT must be set");

--- a/src/routes/office_lamp_routes.rs
+++ b/src/routes/office_lamp_routes.rs
@@ -1,22 +1,22 @@
 use rocket::serde::json::Json;
 
 use crate::services::govee_api_service::sent_put_request;
-use crate::{get_govee_api_key, office_light_setup};
+use crate::{get_govee_api_key, office_light_setup, get_goove_root_url};
 
 #[get("/on")]
 pub async fn office_on_handler() -> Json<serde_json::Value> {
     let govee_api_key = get_govee_api_key();
-    let govee_api_url = "https://developer-api.govee.com/v1/devices/control";
+    let govee_root_url = get_goove_root_url();
     let payload = office_light_setup("on");
-    sent_put_request(govee_api_url, &govee_api_key, payload).await;
+    sent_put_request(&govee_root_url, &govee_api_key, payload).await;
     Json(serde_json::json!({"device": "office_light", "status": "on"}))
 }
 
 #[get("/off")]
 pub async fn office_off_handler() -> Json<serde_json::Value> {
     let govee_api_key = get_govee_api_key();
-    let govee_api_url = "https://developer-api.govee.com/v1/devices/control";
+    let govee_root_url = get_goove_root_url();
     let payload = office_light_setup("off");
-    sent_put_request(govee_api_url, &govee_api_key, payload).await;
+    sent_put_request(&govee_root_url, &govee_api_key, payload).await;
     Json(serde_json::json!({"device": "office_light", "status": "off"}))
 }

--- a/src/routes/tv_lamp_routes.rs
+++ b/src/routes/tv_lamp_routes.rs
@@ -1,22 +1,22 @@
 use rocket::serde::json::Json;
 
 use crate::services::govee_api_service::sent_put_request;
-use crate::{get_govee_api_key, tv_light_setup};
+use crate::{get_govee_api_key, tv_light_setup, get_goove_root_url};
 
 #[get("/on")]
 pub async fn tv_on_handler() -> Json<serde_json::Value> {
     let govee_api_key = get_govee_api_key();
-    let govee_api_url = "https://developer-api.govee.com/v1/devices/control";
+    let govee_root_url = get_goove_root_url();
     let payload = tv_light_setup("on");
-    sent_put_request(govee_api_url, &govee_api_key, payload).await;
+    sent_put_request(&govee_root_url, &govee_api_key, payload).await;
     Json(serde_json::json!({"device": "tv_light", "status": "on"}))
 }
 
 #[get("/off")]
 pub async fn tv_off_handler() -> Json<serde_json::Value> {
     let govee_api_key = get_govee_api_key();
-    let govee_api_url = "https://developer-api.govee.com/v1/devices/control";
+    let govee_root_url = get_goove_root_url();
     let payload = tv_light_setup("off");
-    sent_put_request(govee_api_url, &govee_api_key, payload).await;
+    sent_put_request(&govee_root_url, &govee_api_key, payload).await;
     Json(serde_json::json!({"device": "tv_light", "status": "off"}))
 }


### PR DESCRIPTION
Use GOVEE_ROOT_URL to hide all variables. That was the only one exposed.