### PR TITLE
use govee-api v.1.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -707,6 +707,8 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 [[package]]
 name = "govee-api"
 version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56c57ecb28f0502063f525713471f14bf914c4c256950626e5c8901904bc809"
 dependencies = [
  "lazy_static",
  "reqwest",
@@ -1702,7 +1704,7 @@ dependencies = [
 
 [[package]]
 name = "rust_that_light"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "cargo-tarpaulin",
  "dotenv",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -706,9 +706,7 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "govee-api"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08a50776a73e0c05ad6aab5aafb339e376d92c82548485e87e3d213c80f09b1e"
+version = "1.1.0"
 dependencies = [
  "lazy_static",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ reqwest = {version = "0.11.14", features = ["blocking", "json"]}
 serde = {version = "1.0.183", features = ["derive"]}
 serde_json = "1.0.104"
 lazy_static = "1.4.0"
-govee-api = {version = "1.0.3"}
-# govee-api = {version = "1.0.3", path = "../../govee-api.git/handle_errors"}
+# govee-api = {version = "1.1.0"}
+govee-api = {version = "1.1.0", path = "../../govee-api.git/handle_errors"}
 
 [dependencies.rocket]
 version = "0.5.0-rc.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rust_that_light"
 authors = ["Maciej Gierada @mgierada"]
-version = "0.3.2"
+version = "0.4.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -12,8 +12,8 @@ reqwest = {version = "0.11.14", features = ["blocking", "json"]}
 serde = {version = "1.0.183", features = ["derive"]}
 serde_json = "1.0.104"
 lazy_static = "1.4.0"
-# govee-api = {version = "1.1.0"}
-govee-api = {version = "1.1.0", path = "../../govee-api.git/handle_errors"}
+govee-api = {version = "1.1.0"}
+# govee-api = {version = "1.1.0", path = "../../govee-api.git/handle_errors"}
 
 [dependencies.rocket]
 version = "0.5.0-rc.1"

--- a/src/routes/all_devices_routes.rs
+++ b/src/routes/all_devices_routes.rs
@@ -9,10 +9,17 @@ use rocket::serde::json::Json;
 #[get("/devices")]
 pub async fn get_all_devices_handler() -> Json<serde_json::Value> {
     let govee_client = GoveeClient::new(&GOVEE_API_KEY);
-    let response: ApiResponseGoveeDevices = govee_client.get_devices().await;
-    let raw_devices = response.data.unwrap().devices;
-    let wrapped_devices = wrap_devices(raw_devices);
-    Json(serde_json::json!({ "devices": wrapped_devices }))
+    match govee_client.get_devices().await {
+        Ok(response) => {
+            let raw_devices = response.data.unwrap().devices;
+            let wrapped_devices = wrap_devices(raw_devices);
+            Json(serde_json::json!({ "devices": wrapped_devices }))
+        }
+        Err(err) => {
+            println!("Error: {}", err);
+            Json(serde_json::json!({"error": "Failed to fetch devices"}))
+        }
+    }
 }
 
 #[get("/status")]

--- a/src/routes/all_devices_routes.rs
+++ b/src/routes/all_devices_routes.rs
@@ -2,43 +2,89 @@ use crate::wrappers::all_devices_wrapper::{
     wrap_device_status, wrap_devices, wrap_model_and_devices, DeviceStatus,
 };
 use crate::GOVEE_API_KEY;
-use govee_api::structs::govee::{ApiResponseGoveeDeviceState, ApiResponseGoveeDevices};
+use govee_api::structs::govee::{ApiResponseGoveeDeviceState, ApiResponseGoveeDevices, GoveeDevice};
 use govee_api::GoveeClient;
 use rocket::serde::json::Json;
+use rocket::http::Status;
+use rocket::response::status::Custom;
 
-#[get("/devices")]
-pub async fn get_all_devices_handler() -> Json<serde_json::Value> {
-    let govee_client = GoveeClient::new(&GOVEE_API_KEY);
+async fn get_devices_handler(govee_client: GoveeClient) -> Result<Vec<GoveeDevice>, Custom<Json<serde_json::Value>>> {
     match govee_client.get_devices().await {
         Ok(response) => {
             let raw_devices = response.data.unwrap().devices;
-            let wrapped_devices = wrap_devices(raw_devices);
-            Json(serde_json::json!({ "devices": wrapped_devices }))
+            // let wrapped_devices = wrap_devices(raw_devices);
+            // Ok(Json(serde_json::json!({ "devices": wrapped_devices })))
+            Ok(raw_devices)
         }
         Err(err) => {
             println!("Error: {}", err);
-            Json(serde_json::json!({"error": "Failed to fetch devices"}))
+            let error_json = serde_json::json!({ "error": "Failed to fetch devices" });
+            Err(Custom(Status::BadRequest, Json(error_json)))
         }
     }
 }
 
+#[get("/devices")]
+pub async fn get_all_devices_handler() -> Result<Json<serde_json::Value>, Custom<Json<serde_json::Value>>> {
+    let govee_client = GoveeClient::new(&GOVEE_API_KEY);
+    match get_devices_handler(govee_client).await {
+        Ok(raw_devices) => {
+            let wrapped_devices = wrap_devices(raw_devices);
+            Ok(Json(serde_json::json!({ "devices": wrapped_devices })))
+        }
+        Err(err) => {
+            Err(err)  // Just propagate the error without wrapping it again
+        }
+    }
+}
+// #[get("/devices")]
+// pub async fn get_all_devices_handler() -> Json<serde_json::Value> {
+//     let govee_client = GoveeClient::new(&GOVEE_API_KEY);
+//     let raw_devices = get_devices_handler(govee_client).await;
+//     let wrapped_devices = wrap_devices(raw_devices);
+//     Json(serde_json::json!({ "devices": wrapped_devices }))
+//     // match govee_client.get_devices().await {
+//     //     Ok(response) => {
+//     //         let raw_devices = response.data.unwrap().devices;
+//     //         let wrapped_devices = wrap_devices(raw_devices);
+//     //         Json(serde_json::json!({ "devices": wrapped_devices }))
+//     //     }
+//     //     Err(err) => {
+//     //         println!("Error: {}", err);
+//     //         Json(serde_json::json!({"error": "Failed to fetch devices"}))
+//     //     }
+//     // }
+// }
+
 #[get("/status")]
 pub async fn get_status_for_all_devices() -> Json<serde_json::Value> {
     let govee_client = GoveeClient::new(&GOVEE_API_KEY);
-    let response: ApiResponseGoveeDevices = govee_client.get_devices().await;
-    let raw_devices = response.data.unwrap().devices;
-    let wrapped_models_and_devices = wrap_model_and_devices(raw_devices);
 
+    let raw_devices = get_devices_handler(govee_client).await;
+    // let response: ApiResponseGoveeDevices = govee_client.get_devices().await;
+    // let raw_devices = response.data.unwrap().devices;
+    let wrapped_models_and_devices = wrap_model_and_devices(raw_devices);
     let mut response_status: Vec<DeviceStatus> = Vec::new();
     for model_and_device in wrapped_models_and_devices {
         let device = model_and_device.device;
         let model = model_and_device.model;
         let govee_client = GoveeClient::new(&GOVEE_API_KEY);
-        let raw_response: ApiResponseGoveeDeviceState =
-            govee_client.get_device_state(&device, &model).await;
-        let raw_devices_status = raw_response.data.unwrap();
-        let response = wrap_device_status(raw_devices_status);
-        response_status.push(response);
+        // let raw_response: ApiResponseGoveeDeviceState =
+        //     govee_client.get_device_state(&device, &model).await;
+        match govee_client.get_device_state(&device, &model).await {
+            Ok(response) => {
+                let raw_devices_status = response.data.unwrap();
+                let response = wrap_device_status(raw_devices_status);
+                response_status.push(response);
+            }
+            Err(err) => {
+                println!("Error: {}", err);
+                Json(serde_json::json!({"error": "Failed to fetch devices"}))
+            }
+        }
+        // let raw_devices_status = raw_response.data.unwrap();
+        // let response = wrap_device_status(raw_devices_status);
+        // response_status.push(response);
     }
     Json(serde_json::json!({ "status": response_status }))
 }

--- a/src/routes/all_devices_routes.rs
+++ b/src/routes/all_devices_routes.rs
@@ -2,8 +2,7 @@ use crate::wrappers::all_devices_wrapper::{
     wrap_device_status, wrap_devices, wrap_model_and_devices, DeviceStatus,
 };
 use crate::GOVEE_API_KEY;
-use govee_api::structs::govee::{ApiResponseGoveeDeviceState, GoveeDevice};
-use govee_api::GoveeClient;
+use govee_api::{structs::govee::GoveeDevice, GoveeClient};
 use rocket::http::Status;
 use rocket::response::status::Custom;
 use rocket::serde::json::Json;
@@ -51,8 +50,6 @@ pub async fn get_status_for_all_devices(
                 let device = model_and_device.device;
                 let model = model_and_device.model;
                 let govee_client = GoveeClient::new(&GOVEE_API_KEY);
-                // let raw_response: ApiResponseGoveeDeviceState =
-                //     govee_client.get_device_state(&device, &model).await;
                 match govee_client.get_device_state(&device, &model).await {
                     Ok(response) => {
                         let raw_devices_status = response.data.unwrap();

--- a/src/routes/all_devices_routes.rs
+++ b/src/routes/all_devices_routes.rs
@@ -43,9 +43,6 @@ pub async fn get_all_devices_handler(
 pub async fn get_status_for_all_devices(
 ) -> Result<Json<serde_json::Value>, Custom<Json<serde_json::Value>>> {
     let govee_client = GoveeClient::new(&GOVEE_API_KEY);
-    // let raw_devices = get_devices_handler(govee_client).await;
-    // let response: ApiResponseGoveeDevices = govee_client.get_devices().await;
-    // let raw_devices = response.data.unwrap().devices;
     match get_devices_handler(govee_client).await {
         Ok(raw_devices) => {
             let wrapped_models_and_devices = wrap_model_and_devices(raw_devices);
@@ -73,38 +70,21 @@ pub async fn get_status_for_all_devices(
         }
         Err(err) => Err(err),
     }
-
-    // let wrapped_models_and_devices = wrap_model_and_devices(raw_devices);
-    // let mut response_status: Vec<DeviceStatus> = Vec::new();
-    // for model_and_device in wrapped_models_and_devices {
-    //     let device = model_and_device.device;
-    //     let model = model_and_device.model;
-    //     let govee_client = GoveeClient::new(&GOVEE_API_KEY);
-    //     // let raw_response: ApiResponseGoveeDeviceState =
-    //     //     govee_client.get_device_state(&device, &model).await;
-    //     match govee_client.get_device_state(&device, &model).await {
-    //         Ok(response) => {
-    //             let raw_devices_status = response.data.unwrap();
-    //             let response = wrap_device_status(raw_devices_status);
-    //             response_status.push(response);
-    //         }
-    //         Err(err) => {
-    //             println!("Error: {}", err);
-    //             Json(serde_json::json!({"error": "Failed to fetch devices"}))
-    //         }
-    //     }
-    //     // let raw_devices_status = raw_response.data.unwrap();
-    //     // let response = wrap_device_status(raw_devices_status);
-    //     // response_status.push(response);
-    // }
-    // Json(serde_json::json!({ "status": response_status }))
 }
 
 #[get("/status/<device>/<model>")]
 pub async fn get_status_for_device(device: String, model: String) -> Json<serde_json::Value> {
     let govee_client = GoveeClient::new(&GOVEE_API_KEY);
-    let raw_response: ApiResponseGoveeDeviceState =
-        govee_client.get_device_state(&device, &model).await;
-    let raw_devices_status = raw_response.data.unwrap();
-    Json(serde_json::json!({ "status": raw_devices_status }))
+    match govee_client.get_device_state(&device, &model).await {
+        Ok(response) => {
+            let raw_devices_status = response.data.unwrap();
+            let response = wrap_device_status(raw_devices_status);
+            Json(serde_json::json!({ "status": response }))
+        }
+        Err(err) => {
+            println!("Error: {}", err);
+            let error_json = serde_json::json!({ "error": "Failed to fetch devices" });
+            Json(error_json)
+        }
+    }
 }

--- a/src/routes/all_devices_routes.rs
+++ b/src/routes/all_devices_routes.rs
@@ -2,18 +2,18 @@ use crate::wrappers::all_devices_wrapper::{
     wrap_device_status, wrap_devices, wrap_model_and_devices, DeviceStatus,
 };
 use crate::GOVEE_API_KEY;
-use govee_api::structs::govee::{ApiResponseGoveeDeviceState, ApiResponseGoveeDevices, GoveeDevice};
+use govee_api::structs::govee::{ApiResponseGoveeDeviceState, GoveeDevice};
 use govee_api::GoveeClient;
-use rocket::serde::json::Json;
 use rocket::http::Status;
 use rocket::response::status::Custom;
+use rocket::serde::json::Json;
 
-async fn get_devices_handler(govee_client: GoveeClient) -> Result<Vec<GoveeDevice>, Custom<Json<serde_json::Value>>> {
+async fn get_devices_handler(
+    govee_client: GoveeClient,
+) -> Result<Vec<GoveeDevice>, Custom<Json<serde_json::Value>>> {
     match govee_client.get_devices().await {
         Ok(response) => {
             let raw_devices = response.data.unwrap().devices;
-            // let wrapped_devices = wrap_devices(raw_devices);
-            // Ok(Json(serde_json::json!({ "devices": wrapped_devices })))
             Ok(raw_devices)
         }
         Err(err) => {
@@ -25,7 +25,8 @@ async fn get_devices_handler(govee_client: GoveeClient) -> Result<Vec<GoveeDevic
 }
 
 #[get("/devices")]
-pub async fn get_all_devices_handler() -> Result<Json<serde_json::Value>, Custom<Json<serde_json::Value>>> {
+pub async fn get_all_devices_handler(
+) -> Result<Json<serde_json::Value>, Custom<Json<serde_json::Value>>> {
     let govee_client = GoveeClient::new(&GOVEE_API_KEY);
     match get_devices_handler(govee_client).await {
         Ok(raw_devices) => {
@@ -33,60 +34,70 @@ pub async fn get_all_devices_handler() -> Result<Json<serde_json::Value>, Custom
             Ok(Json(serde_json::json!({ "devices": wrapped_devices })))
         }
         Err(err) => {
-            Err(err)  // Just propagate the error without wrapping it again
+            Err(err) // Just propagate the error without wrapping it again
         }
     }
 }
-// #[get("/devices")]
-// pub async fn get_all_devices_handler() -> Json<serde_json::Value> {
-//     let govee_client = GoveeClient::new(&GOVEE_API_KEY);
-//     let raw_devices = get_devices_handler(govee_client).await;
-//     let wrapped_devices = wrap_devices(raw_devices);
-//     Json(serde_json::json!({ "devices": wrapped_devices }))
-//     // match govee_client.get_devices().await {
-//     //     Ok(response) => {
-//     //         let raw_devices = response.data.unwrap().devices;
-//     //         let wrapped_devices = wrap_devices(raw_devices);
-//     //         Json(serde_json::json!({ "devices": wrapped_devices }))
-//     //     }
-//     //     Err(err) => {
-//     //         println!("Error: {}", err);
-//     //         Json(serde_json::json!({"error": "Failed to fetch devices"}))
-//     //     }
-//     // }
-// }
 
 #[get("/status")]
-pub async fn get_status_for_all_devices() -> Json<serde_json::Value> {
+pub async fn get_status_for_all_devices(
+) -> Result<Json<serde_json::Value>, Custom<Json<serde_json::Value>>> {
     let govee_client = GoveeClient::new(&GOVEE_API_KEY);
-
-    let raw_devices = get_devices_handler(govee_client).await;
+    // let raw_devices = get_devices_handler(govee_client).await;
     // let response: ApiResponseGoveeDevices = govee_client.get_devices().await;
     // let raw_devices = response.data.unwrap().devices;
-    let wrapped_models_and_devices = wrap_model_and_devices(raw_devices);
-    let mut response_status: Vec<DeviceStatus> = Vec::new();
-    for model_and_device in wrapped_models_and_devices {
-        let device = model_and_device.device;
-        let model = model_and_device.model;
-        let govee_client = GoveeClient::new(&GOVEE_API_KEY);
-        // let raw_response: ApiResponseGoveeDeviceState =
-        //     govee_client.get_device_state(&device, &model).await;
-        match govee_client.get_device_state(&device, &model).await {
-            Ok(response) => {
-                let raw_devices_status = response.data.unwrap();
-                let response = wrap_device_status(raw_devices_status);
-                response_status.push(response);
+    match get_devices_handler(govee_client).await {
+        Ok(raw_devices) => {
+            let wrapped_models_and_devices = wrap_model_and_devices(raw_devices);
+            let mut response_status: Vec<DeviceStatus> = Vec::new();
+            for model_and_device in wrapped_models_and_devices {
+                let device = model_and_device.device;
+                let model = model_and_device.model;
+                let govee_client = GoveeClient::new(&GOVEE_API_KEY);
+                // let raw_response: ApiResponseGoveeDeviceState =
+                //     govee_client.get_device_state(&device, &model).await;
+                match govee_client.get_device_state(&device, &model).await {
+                    Ok(response) => {
+                        let raw_devices_status = response.data.unwrap();
+                        let response = wrap_device_status(raw_devices_status);
+                        response_status.push(response);
+                    }
+                    Err(err) => {
+                        println!("Error: {}", err);
+                        let error_json = serde_json::json!({ "error": "Failed to fetch devices" });
+                        return Err(Custom(Status::BadRequest, Json(error_json)));
+                    }
+                }
             }
-            Err(err) => {
-                println!("Error: {}", err);
-                Json(serde_json::json!({"error": "Failed to fetch devices"}))
-            }
+            Ok(Json(serde_json::json!({ "status": response_status })))
         }
-        // let raw_devices_status = raw_response.data.unwrap();
-        // let response = wrap_device_status(raw_devices_status);
-        // response_status.push(response);
+        Err(err) => Err(err),
     }
-    Json(serde_json::json!({ "status": response_status }))
+
+    // let wrapped_models_and_devices = wrap_model_and_devices(raw_devices);
+    // let mut response_status: Vec<DeviceStatus> = Vec::new();
+    // for model_and_device in wrapped_models_and_devices {
+    //     let device = model_and_device.device;
+    //     let model = model_and_device.model;
+    //     let govee_client = GoveeClient::new(&GOVEE_API_KEY);
+    //     // let raw_response: ApiResponseGoveeDeviceState =
+    //     //     govee_client.get_device_state(&device, &model).await;
+    //     match govee_client.get_device_state(&device, &model).await {
+    //         Ok(response) => {
+    //             let raw_devices_status = response.data.unwrap();
+    //             let response = wrap_device_status(raw_devices_status);
+    //             response_status.push(response);
+    //         }
+    //         Err(err) => {
+    //             println!("Error: {}", err);
+    //             Json(serde_json::json!({"error": "Failed to fetch devices"}))
+    //         }
+    //     }
+    //     // let raw_devices_status = raw_response.data.unwrap();
+    //     // let response = wrap_device_status(raw_devices_status);
+    //     // response_status.push(response);
+    // }
+    // Json(serde_json::json!({ "status": response_status }))
 }
 
 #[get("/status/<device>/<model>")]


### PR DESCRIPTION
Use `govee-api` v.1.1.0 to control your Govee devices. That version of library introduces improved error handling.