### PR TITLE
Use govee-api v 1.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ reqwest = {version = "0.11.14", features = ["blocking", "json"]}
 serde = {version = "1.0.184", features = ["derive"]}
 serde_json = "1.0.105"
 lazy_static = "1.4.0"
-govee-api = {version = "1.1.0"}
+govee-api = {version = "1.1.1"}
 # govee-api = {version = "1.1.0", path = "../../govee-api.git/handle_errors"}
 
 [dependencies.rocket]


### PR DESCRIPTION
Use the latest govee-api version 1.1.1.