### PR TITLE
Make test green again

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,6 +12,8 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      GOVEE_API_KEY: ${{ secrets.GOVEE_API_KEY }}
     steps:
       - uses: actions/checkout@v3
       - name: Build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1232,7 +1232,7 @@ dependencies = [
 
 [[package]]
 name = "rust_that_light"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "dotenv",
  "govee-api",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1232,7 +1232,7 @@ dependencies = [
 
 [[package]]
 name = "rust_that_light"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "dotenv",
  "govee-api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rust_that_light"
 authors = ["Maciej Gierada @mgierada"]
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Making sure all tests are green again.

Tests are falling because `GOVEE_API_KEY` is not defined on the CI server.