### PR TITLE
Add handler for table led light

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1232,7 +1232,7 @@ dependencies = [
 
 [[package]]
 name = "rust_that_light"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "dotenv",
  "govee-api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rust_that_light"
 authors = ["Maciej Gierada @mgierada"]
-version = "0.4.2"
+version = "0.5.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,0 +1,1 @@
+pub mod enums;

--- a/src/constants/enums.rs
+++ b/src/constants/enums.rs
@@ -1,0 +1,9 @@
+pub struct Device{
+    pub device_id: String,
+    pub model: String
+}
+
+pub enum OfficeDevices {
+    TableLED(Device),
+    CornerLED(Device)
+}

--- a/src/constants/enums.rs
+++ b/src/constants/enums.rs
@@ -1,9 +1,9 @@
-pub struct Device{
+pub struct Device {
     pub device_id: String,
-    pub model: String
+    pub model: String,
 }
 
 pub enum OfficeDevices {
     TableLED(Device),
-    CornerLED(Device)
+    CornerLED(Device),
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ pub mod routes;
 pub mod services;
 pub mod tests;
 pub mod wrappers;
+pub mod constants;
 
 lazy_static! {
     pub static ref GOVEE_API_KEY: String =

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,17 +8,20 @@ use routes::all_devices_routes::{
 };
 use routes::healthcheck_routes::healthcheck_handler;
 use routes::home_routes::home;
-use routes::office_lamp_routes::{office_off_handler, office_on_handler};
+use routes::office_routes::{
+    office_corner_off_handler, office_corner_on_handler, office_table_off_handler,
+    office_table_on_handler,
+};
 use routes::tv_lamp_routes::{tv_off_handler, tv_on_handler};
 use std::env::var;
 
+pub mod constants;
 pub mod error_handlers;
 pub mod implementations;
 pub mod routes;
 pub mod services;
 pub mod tests;
 pub mod wrappers;
-pub mod constants;
 
 lazy_static! {
     pub static ref GOVEE_API_KEY: String =
@@ -39,7 +42,15 @@ fn rocket() -> _ {
     rocket::build()
         .register("/", catchers![ununauthorized, not_found, server_error])
         .mount("/tv", routes![tv_on_handler, tv_off_handler])
-        .mount("/office", routes![office_on_handler, office_off_handler])
+        .mount(
+            "/office",
+            routes![
+                office_corner_on_handler,
+                office_corner_off_handler,
+                office_table_on_handler,
+                office_table_off_handler
+            ],
+        )
         .mount(
             "/",
             routes![

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -1,5 +1,5 @@
 pub mod all_devices_routes;
 pub mod healthcheck_routes;
 pub mod home_routes;
-pub mod office_lamp_routes;
+pub mod office_routes;
 pub mod tv_lamp_routes;

--- a/src/routes/office_lamp_routes.rs
+++ b/src/routes/office_lamp_routes.rs
@@ -1,6 +1,7 @@
 use govee_api::GoveeClient;
 use rocket::serde::json::Json;
 
+use crate::constants::enums::OfficeDevices;
 use crate::implementations::access_token::Token;
 use crate::services::light_setup_service::office_light_setup;
 use crate::GOVEE_API_KEY;
@@ -19,6 +20,17 @@ pub async fn office_on_handler(_token: Token) -> Json<serde_json::Value> {
 #[get("/off")]
 pub async fn office_off_handler(_token: Token) -> Json<serde_json::Value> {
     let payload = office_light_setup("off");
+    let govee_client = GoveeClient::new(&GOVEE_API_KEY);
+    let result = govee_client.control_device(payload).await;
+    if let Err(err) = result {
+        panic!("Error occurred: {:?}", err);
+    }
+    Json(serde_json::json!({"device": "office_light", "status": "off"}))
+}
+
+#[get("/table/on")]
+pub async fn office_table_on_handler(_token: Token) -> Json<serde_json::Value> {
+    let payload = office_light_setup(OfficeDevices::TableLED(_), "on");
     let govee_client = GoveeClient::new(&GOVEE_API_KEY);
     let result = govee_client.control_device(payload).await;
     if let Err(err) = result {

--- a/src/routes/office_routes.rs
+++ b/src/routes/office_routes.rs
@@ -8,26 +8,26 @@ use crate::GOVEE_API_KEY;
 
 #[get("/corner/on")]
 pub async fn office_corner_on_handler(_token: Token) -> Json<serde_json::Value> {
-    let corner_led= OfficeDevices::corner_led();
+    let corner_led = OfficeDevices::corner_led();
     let payload = office_light_setup(&corner_led, "on");
     let govee_client = GoveeClient::new(&GOVEE_API_KEY);
     let result = govee_client.control_device(payload).await;
     if let Err(err) = result {
         panic!("Error occurred: {:?}", err);
     }
-    Json(serde_json::json!({"device": "office_light", "status": "on"}))
+    Json(serde_json::json!({"device": "corner_led", "status": "on"}))
 }
 
 #[get("/corner/off")]
 pub async fn office_corner_off_handler(_token: Token) -> Json<serde_json::Value> {
-    let corner_led= OfficeDevices::corner_led();
+    let corner_led = OfficeDevices::corner_led();
     let payload = office_light_setup(&corner_led, "off");
     let govee_client = GoveeClient::new(&GOVEE_API_KEY);
     let result = govee_client.control_device(payload).await;
     if let Err(err) = result {
         panic!("Error occurred: {:?}", err);
     }
-    Json(serde_json::json!({"device": "office_light", "status": "off"}))
+    Json(serde_json::json!({"device": "corner_led", "status": "off"}))
 }
 
 #[get("/table/on")]
@@ -39,7 +39,7 @@ pub async fn office_table_on_handler(_token: Token) -> Json<serde_json::Value> {
     if let Err(err) = result {
         panic!("Error occurred: {:?}", err);
     }
-    Json(serde_json::json!({"device": "office_light", "status": "off"}))
+    Json(serde_json::json!({"device": "table_led", "status": "on"}))
 }
 
 #[get("/table/off")]
@@ -51,5 +51,5 @@ pub async fn office_table_off_handler(_token: Token) -> Json<serde_json::Value> 
     if let Err(err) = result {
         panic!("Error occurred: {:?}", err);
     }
-    Json(serde_json::json!({"device": "office_light", "status": "off"}))
+    Json(serde_json::json!({"device": "table_led", "status": "off"}))
 }

--- a/src/routes/office_routes.rs
+++ b/src/routes/office_routes.rs
@@ -6,9 +6,10 @@ use crate::implementations::access_token::Token;
 use crate::services::light_setup_service::office_light_setup;
 use crate::GOVEE_API_KEY;
 
-#[get("/on")]
-pub async fn office_on_handler(_token: Token) -> Json<serde_json::Value> {
-    let payload = office_light_setup("on");
+#[get("/corner/on")]
+pub async fn office_corner_on_handler(_token: Token) -> Json<serde_json::Value> {
+    let corner_led= OfficeDevices::corner_led();
+    let payload = office_light_setup(&corner_led, "on");
     let govee_client = GoveeClient::new(&GOVEE_API_KEY);
     let result = govee_client.control_device(payload).await;
     if let Err(err) = result {
@@ -17,9 +18,10 @@ pub async fn office_on_handler(_token: Token) -> Json<serde_json::Value> {
     Json(serde_json::json!({"device": "office_light", "status": "on"}))
 }
 
-#[get("/off")]
-pub async fn office_off_handler(_token: Token) -> Json<serde_json::Value> {
-    let payload = office_light_setup("off");
+#[get("/corner/off")]
+pub async fn office_corner_off_handler(_token: Token) -> Json<serde_json::Value> {
+    let corner_led= OfficeDevices::corner_led();
+    let payload = office_light_setup(&corner_led, "off");
     let govee_client = GoveeClient::new(&GOVEE_API_KEY);
     let result = govee_client.control_device(payload).await;
     if let Err(err) = result {
@@ -30,7 +32,20 @@ pub async fn office_off_handler(_token: Token) -> Json<serde_json::Value> {
 
 #[get("/table/on")]
 pub async fn office_table_on_handler(_token: Token) -> Json<serde_json::Value> {
-    let payload = office_light_setup(OfficeDevices::TableLED(_), "on");
+    let table_led = OfficeDevices::table_led();
+    let payload = office_light_setup(&table_led, "on");
+    let govee_client = GoveeClient::new(&GOVEE_API_KEY);
+    let result = govee_client.control_device(payload).await;
+    if let Err(err) = result {
+        panic!("Error occurred: {:?}", err);
+    }
+    Json(serde_json::json!({"device": "office_light", "status": "off"}))
+}
+
+#[get("/table/off")]
+pub async fn office_table_off_handler(_token: Token) -> Json<serde_json::Value> {
+    let table_led = OfficeDevices::table_led();
+    let payload = office_light_setup(&table_led, "off");
     let govee_client = GoveeClient::new(&GOVEE_API_KEY);
     let result = govee_client.control_device(payload).await;
     if let Err(err) = result {

--- a/src/services/light_setup_service.rs
+++ b/src/services/light_setup_service.rs
@@ -1,12 +1,14 @@
 use std::env::var;
 
-use govee_api::structs::govee::{PayloadBody, GoveeCommand};
+use govee_api::structs::govee::{GoveeCommand, PayloadBody};
+
+use crate::constants::enums::{Device, OfficeDevices};
 
 pub fn tv_light_setup(command: &str) -> PayloadBody {
     let goove_api_device =
         var("GOVEE_DEVICE_ID_TV_LIGHT").expect("GOVEE_DEVICE_ID_TV_LIGHT must be set");
     let goove_model = var("GOVEE_MODEL_TV_LIGHT").expect("GOVEE_MODEL_TV_LIGHT must be set");
-    let command = GoveeCommand{
+    let command = GoveeCommand {
         name: "turn".to_string(),
         value: command.to_string(),
     };
@@ -17,18 +19,30 @@ pub fn tv_light_setup(command: &str) -> PayloadBody {
     }
 }
 
-pub fn office_light_setup(command: &str) -> PayloadBody {
-    let goove_api_device =
-        var("GOVEE_DEVICE_ID_OFFICE_LIGHT").expect("GOVEE_DEVICE_ID_OFFICE_LIGHT must be set");
-    let goove_model =
-        var("GOVEE_MODEL_OFFICE_LIGHT").expect("GOVEE_MODEL_OFFICE_LIGHT must be set");
+pub fn office_light_setup(device: &OfficeDevices, command: &str) -> PayloadBody {
+    let office_corner_light_id =
+        var("OFFICE_CORNER_LIGHT_ID").expect("OFFICE_CORNER_LIGHT_ID must be set");
+    let office_corner_light_model =
+        var("OFFICE_CORNER_LIGHT_MODEL").expect("OFFICE_CORNER_LIGHT_MODEL must be set");
+    let office_table_led_id = var("OFFICE_TABLE_LED_ID").expect("OFFICE_TABLE_LED_ID must be set");
+    let office_table_led_model =
+        var("OFFICE_TABLE_LED_MODEL").expect("OFFICE_TABLE_LED_MODEL must be set");
+
     let command = GoveeCommand {
         name: "turn".to_string(),
         value: command.to_string(),
     };
-    PayloadBody {
-        device: goove_api_device,
-        model: goove_model,
-        cmd: command,
+
+    match device {
+        OfficeDevices::CornerLED(_) => PayloadBody {
+            device: office_corner_light_id,
+            model: office_corner_light_model,
+            cmd: command,
+        },
+        OfficeDevices::TableLED(_) => PayloadBody {
+            device: office_table_led_id,
+            model: office_table_led_model,
+            cmd: command,
+        },
     }
 }

--- a/src/services/light_setup_service.rs
+++ b/src/services/light_setup_service.rs
@@ -20,7 +20,6 @@ pub fn tv_light_setup(command: &str) -> PayloadBody {
 }
 
 impl OfficeDevices {
-    // Associated functions to create enum variants
     pub fn corner_led() -> Self {
         let office_corner_light_id =
             env::var("OFFICE_CORNER_LIGHT_ID").expect("OFFICE_CORNER_LIGHT_ID must be set");

--- a/src/services/light_setup_service.rs
+++ b/src/services/light_setup_service.rs
@@ -1,4 +1,4 @@
-use std::env::var;
+use std::env::{var, self};
 
 use govee_api::structs::govee::{GoveeCommand, PayloadBody};
 
@@ -19,29 +19,51 @@ pub fn tv_light_setup(command: &str) -> PayloadBody {
     }
 }
 
-pub fn office_light_setup(device: &OfficeDevices, command: &str) -> PayloadBody {
-    let office_corner_light_id =
-        var("OFFICE_CORNER_LIGHT_ID").expect("OFFICE_CORNER_LIGHT_ID must be set");
-    let office_corner_light_model =
-        var("OFFICE_CORNER_LIGHT_MODEL").expect("OFFICE_CORNER_LIGHT_MODEL must be set");
-    let office_table_led_id = var("OFFICE_TABLE_LED_ID").expect("OFFICE_TABLE_LED_ID must be set");
-    let office_table_led_model =
-        var("OFFICE_TABLE_LED_MODEL").expect("OFFICE_TABLE_LED_MODEL must be set");
+impl OfficeDevices {
+    // Associated functions to create enum variants
+    pub fn corner_led() -> Self {
+        let office_corner_light_id = env::var("OFFICE_CORNER_LIGHT_ID")
+            .expect("OFFICE_CORNER_LIGHT_ID must be set");
+        let office_corner_light_model = env::var("OFFICE_CORNER_LIGHT_MODEL")
+            .expect("OFFICE_CORNER_LIGHT_MODEL must be set");
 
+        let corner_led = Device {
+            device_id: office_corner_light_id,
+            model: office_corner_light_model,
+        };
+
+        OfficeDevices::CornerLED(corner_led)
+    }
+
+    pub fn table_led() -> Self {
+        let office_table_led_id = env::var("OFFICE_TABLE_LED_ID")
+            .expect("OFFICE_TABLE_LED_ID must be set");
+        let office_table_led_model = env::var("OFFICE_TABLE_LED_MODEL")
+            .expect("OFFICE_TABLE_LED_MODEL must be set");
+
+        let table_led = Device {
+            device_id: office_table_led_id,
+            model: office_table_led_model,
+        };
+
+        OfficeDevices::TableLED(table_led)
+    }
+}
+
+pub fn office_light_setup(device: &OfficeDevices, command: &str) -> PayloadBody {
     let command = GoveeCommand {
         name: "turn".to_string(),
         value: command.to_string(),
     };
-
     match device {
-        OfficeDevices::CornerLED(_) => PayloadBody {
-            device: office_corner_light_id,
-            model: office_corner_light_model,
+        OfficeDevices::CornerLED(corner_led) => PayloadBody {
+            device: corner_led.device_id.clone(),
+            model: corner_led.model.clone(),
             cmd: command,
         },
-        OfficeDevices::TableLED(_) => PayloadBody {
-            device: office_table_led_id,
-            model: office_table_led_model,
+        OfficeDevices::TableLED(table_led) => PayloadBody {
+            device: table_led.device_id.clone(),
+            model: table_led.model.clone(),
             cmd: command,
         },
     }

--- a/src/services/light_setup_service.rs
+++ b/src/services/light_setup_service.rs
@@ -1,4 +1,4 @@
-use std::env::{var, self};
+use std::env::{self, var};
 
 use govee_api::structs::govee::{GoveeCommand, PayloadBody};
 
@@ -22,10 +22,10 @@ pub fn tv_light_setup(command: &str) -> PayloadBody {
 impl OfficeDevices {
     // Associated functions to create enum variants
     pub fn corner_led() -> Self {
-        let office_corner_light_id = env::var("OFFICE_CORNER_LIGHT_ID")
-            .expect("OFFICE_CORNER_LIGHT_ID must be set");
-        let office_corner_light_model = env::var("OFFICE_CORNER_LIGHT_MODEL")
-            .expect("OFFICE_CORNER_LIGHT_MODEL must be set");
+        let office_corner_light_id =
+            env::var("OFFICE_CORNER_LIGHT_ID").expect("OFFICE_CORNER_LIGHT_ID must be set");
+        let office_corner_light_model =
+            env::var("OFFICE_CORNER_LIGHT_MODEL").expect("OFFICE_CORNER_LIGHT_MODEL must be set");
 
         let corner_led = Device {
             device_id: office_corner_light_id,
@@ -36,10 +36,10 @@ impl OfficeDevices {
     }
 
     pub fn table_led() -> Self {
-        let office_table_led_id = env::var("OFFICE_TABLE_LED_ID")
-            .expect("OFFICE_TABLE_LED_ID must be set");
-        let office_table_led_model = env::var("OFFICE_TABLE_LED_MODEL")
-            .expect("OFFICE_TABLE_LED_MODEL must be set");
+        let office_table_led_id =
+            env::var("OFFICE_TABLE_LED_ID").expect("OFFICE_TABLE_LED_ID must be set");
+        let office_table_led_model =
+            env::var("OFFICE_TABLE_LED_MODEL").expect("OFFICE_TABLE_LED_MODEL must be set");
 
         let table_led = Device {
             device_id: office_table_led_id,

--- a/src/tests/test_error_handlers/test_error_handlers.rs
+++ b/src/tests/test_error_handlers/test_error_handlers.rs
@@ -8,7 +8,7 @@ mod tests {
     #[test]
     fn test_unauthorized_handler() {
         let client = Client::untracked(rocket()).expect("valid rocket instance");
-        let response = client.get("/office/on").dispatch();
+        let response = client.get("/office/corner/on").dispatch();
         assert_eq!(response.status(), Status::Unauthorized);
         let body = response.into_string().expect("response into string");
         let error: AuthError = serde_json::from_str(&body).expect("deserialize error");

--- a/src/tests/test_error_handlers/test_error_handlers.rs
+++ b/src/tests/test_error_handlers/test_error_handlers.rs
@@ -24,7 +24,7 @@ mod tests {
         let error: NotFoundError = serde_json::from_str(&body).expect("deserialize error");
         assert_eq!(error.error, "Page not found");
     }
-    
+
     #[test]
     fn test_server_error_handler() {
         let client = Client::untracked(crate::rocket()).expect("valid rocket instance");


### PR DESCRIPTION
Adding two new routes:

- `GET /v1/routes/office/table/on`
- `GET /v1/routes/office/table/off`

Modify the previous handler to control office light from:

- `GET /v1/routes/office/on`
- `GET /v1/routes/office/off`

to:

- `GET /v1/routes/office/corner/on`
- `GET /v1/routes/office/corner/off`