### PR TITLE
Add a main office on and off handler to control all office devices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1232,7 +1232,7 @@ dependencies = [
 
 [[package]]
 name = "rust_that_light"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "dotenv",
  "govee-api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rust_that_light"
 authors = ["Maciej Gierada @mgierada"]
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,8 +9,9 @@ use routes::all_devices_routes::{
 use routes::healthcheck_routes::healthcheck_handler;
 use routes::home_routes::home;
 use routes::office_routes::{
-    office_corner_off_handler, office_corner_on_handler, office_table_off_handler,
-    office_table_on_handler, office_window_on_handler, office_window_off_handler, office_on_handler, office_off_handler,
+    office_corner_off_handler, office_corner_on_handler, office_off_handler, office_on_handler,
+    office_table_off_handler, office_table_on_handler, office_window_off_handler,
+    office_window_on_handler,
 };
 use routes::tv_lamp_routes::{tv_off_handler, tv_on_handler};
 use std::env::var;

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ use routes::healthcheck_routes::healthcheck_handler;
 use routes::home_routes::home;
 use routes::office_routes::{
     office_corner_off_handler, office_corner_on_handler, office_table_off_handler,
-    office_table_on_handler, office_window_on_handler, office_window_off_handler,
+    office_table_on_handler, office_window_on_handler, office_window_off_handler, office_on_handler, office_off_handler,
 };
 use routes::tv_lamp_routes::{tv_off_handler, tv_on_handler};
 use std::env::var;
@@ -45,6 +45,8 @@ fn rocket() -> _ {
         .mount(
             "/office",
             routes![
+                office_on_handler,
+                office_off_handler,
                 office_corner_on_handler,
                 office_corner_off_handler,
                 office_table_on_handler,

--- a/src/routes/office_routes.rs
+++ b/src/routes/office_routes.rs
@@ -6,6 +6,28 @@ use crate::implementations::access_token::Token;
 use crate::services::light_setup_service::office_light_setup;
 use crate::GOVEE_API_KEY;
 
+#[get("/office/on")]
+pub async fn office_on_handler(_token: Token) -> Json<serde_json::Value> {
+
+    // Turn on all lights in the office
+    let corner_led = OfficeDevices::corner_led();
+    let table_led = OfficeDevices::table_led();
+    let window_led = OfficeDevices::window_led();
+    let govee_client = GoveeClient::new(&GOVEE_API_KEY);
+    let payload = office_light_setup(&corner_led, "on");
+    
+    // 
+    // let govee_client = GoveeClient::new(&GOVEE_API_KEY);
+    // let corner_led = OfficeDevices::corner_led();
+    // let payload = office_light_setup(&corner_led, "on");
+    // let govee_client = GoveeClient::new(&GOVEE_API_KEY);
+    // let result = govee_client.control_device(payload).await;
+    // if let Err(err) = result {
+    //     panic!("Error occurred: {:?}", err);
+    // }
+    // Json(serde_json::json!({"device": "corner_led", "status": "on"}))
+}
+
 #[get("/corner/on")]
 pub async fn office_corner_on_handler(_token: Token) -> Json<serde_json::Value> {
     let corner_led = OfficeDevices::corner_led();

--- a/src/routes/office_routes.rs
+++ b/src/routes/office_routes.rs
@@ -6,26 +6,54 @@ use crate::implementations::access_token::Token;
 use crate::services::light_setup_service::office_light_setup;
 use crate::GOVEE_API_KEY;
 
-#[get("/office/on")]
+#[get("/on")]
 pub async fn office_on_handler(_token: Token) -> Json<serde_json::Value> {
-
-    // Turn on all lights in the office
+    // TODO Refactor this ungly implementation when bulk control is available
     let corner_led = OfficeDevices::corner_led();
     let table_led = OfficeDevices::table_led();
     let window_led = OfficeDevices::window_led();
     let govee_client = GoveeClient::new(&GOVEE_API_KEY);
-    let payload = office_light_setup(&corner_led, "on");
-    
-    // 
-    // let govee_client = GoveeClient::new(&GOVEE_API_KEY);
-    // let corner_led = OfficeDevices::corner_led();
-    // let payload = office_light_setup(&corner_led, "on");
-    // let govee_client = GoveeClient::new(&GOVEE_API_KEY);
-    // let result = govee_client.control_device(payload).await;
-    // if let Err(err) = result {
-    //     panic!("Error occurred: {:?}", err);
-    // }
-    // Json(serde_json::json!({"device": "corner_led", "status": "on"}))
+    let payload_corner = office_light_setup(&corner_led, "on");
+    let payload_table = office_light_setup(&table_led, "on");
+    let payload_window = office_light_setup(&window_led, "on");
+    let result_corner = govee_client.control_device(payload_corner).await;
+    let result_table = govee_client.control_device(payload_table).await;
+    let result_window = govee_client.control_device(payload_window).await;
+    if let Err(err) = result_corner {
+        panic!("Error occurred: {:?}", err);
+    }
+    if let Err(err) = result_table {
+        panic!("Error occurred: {:?}", err);
+    }
+    if let Err(err) = result_window {
+        panic!("Error occurred: {:?}", err);
+    }
+    Json(serde_json::json!({"device": "all", "status": "on"}))
+}
+
+#[get("/off")]
+pub async fn office_off_handler(_token: Token) -> Json<serde_json::Value> {
+    // TODO Refactor this ungly implementatioff when bulk control is available
+    let corner_led = OfficeDevices::corner_led();
+    let table_led = OfficeDevices::table_led();
+    let window_led = OfficeDevices::window_led();
+    let govee_client = GoveeClient::new(&GOVEE_API_KEY);
+    let payload_corner = office_light_setup(&corner_led, "off");
+    let payload_table = office_light_setup(&table_led, "off");
+    let payload_window = office_light_setup(&window_led, "off");
+    let result_corner = govee_client.control_device(payload_corner).await;
+    let result_table = govee_client.control_device(payload_table).await;
+    let result_window = govee_client.control_device(payload_window).await;
+    if let Err(err) = result_corner {
+        panic!("Error occurred: {:?}", err);
+    }
+    if let Err(err) = result_table {
+        panic!("Error occurred: {:?}", err);
+    }
+    if let Err(err) = result_window {
+        panic!("Error occurred: {:?}", err);
+    }
+    Json(serde_json::json!({"device": "all", "status": "on"}))
 }
 
 #[get("/corner/on")]

--- a/src/routes/office_routes.rs
+++ b/src/routes/office_routes.rs
@@ -8,7 +8,7 @@ use crate::GOVEE_API_KEY;
 
 #[get("/on")]
 pub async fn office_on_handler(_token: Token) -> Json<serde_json::Value> {
-    // TODO Refactor this ungly implementation when bulk control is available
+    // TODO Refactor this ugly implementation when bulk control is available
     let corner_led = OfficeDevices::corner_led();
     let table_led = OfficeDevices::table_led();
     let window_led = OfficeDevices::window_led();
@@ -33,7 +33,7 @@ pub async fn office_on_handler(_token: Token) -> Json<serde_json::Value> {
 
 #[get("/off")]
 pub async fn office_off_handler(_token: Token) -> Json<serde_json::Value> {
-    // TODO Refactor this ungly implementatioff when bulk control is available
+    // TODO Refactor this ugly implementation when bulk control is available
     let corner_led = OfficeDevices::corner_led();
     let table_led = OfficeDevices::table_led();
     let window_led = OfficeDevices::window_led();


### PR DESCRIPTION
Adding new handlers to control all of the office devices in a single request:

- [x] `GET /office/on`
- [x] `GET /office/off`