### PR TITLE
Add board light handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1232,7 +1232,7 @@ dependencies = [
 
 [[package]]
 name = "rust_that_light"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "dotenv",
  "govee-api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rust_that_light"
 authors = ["Maciej Gierada @mgierada"]
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/constants/enums.rs
+++ b/src/constants/enums.rs
@@ -6,5 +6,6 @@ pub struct Device {
 pub enum OfficeDevices {
     TableLED(Device),
     CornerLED(Device),
-    WindowLED(Device)
+    WindowLED(Device),
+    BoardLED(Device),
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use routes::home_routes::home;
 use routes::office_routes::{
     office_corner_off_handler, office_corner_on_handler, office_off_handler, office_on_handler,
     office_table_off_handler, office_table_on_handler, office_window_off_handler,
-    office_window_on_handler,
+    office_window_on_handler, office_board_on_handler, office_board_off_on_handler,
 };
 use routes::tv_lamp_routes::{tv_off_handler, tv_on_handler};
 use std::env::var;
@@ -53,7 +53,9 @@ fn rocket() -> _ {
                 office_table_on_handler,
                 office_table_off_handler,
                 office_window_on_handler,
-                office_window_off_handler
+                office_window_off_handler,
+                office_board_on_handler,
+                office_board_off_on_handler
             ],
         )
         .mount(

--- a/src/routes/office_routes.rs
+++ b/src/routes/office_routes.rs
@@ -43,13 +43,16 @@ pub async fn office_off_handler(_token: Token) -> Json<serde_json::Value> {
     let corner_led = OfficeDevices::corner_led();
     let table_led = OfficeDevices::table_led();
     let window_led = OfficeDevices::window_led();
-    let govee_client = GoveeClient::new(&GOVEE_API_KEY);
+    let board_led = OfficeDevices::board_led();
     let payload_corner = office_light_setup(&corner_led, "off");
     let payload_table = office_light_setup(&table_led, "off");
     let payload_window = office_light_setup(&window_led, "off");
+    let payload_board = office_light_setup(&board_led, "off");
+    let govee_client = GoveeClient::new(&GOVEE_API_KEY);
     let result_corner = govee_client.control_device(payload_corner).await;
     let result_table = govee_client.control_device(payload_table).await;
     let result_window = govee_client.control_device(payload_window).await;
+    let result_board = govee_client.control_device(payload_board).await;
     if let Err(err) = result_corner {
         panic!("Error occurred: {:?}", err);
     }
@@ -57,6 +60,9 @@ pub async fn office_off_handler(_token: Token) -> Json<serde_json::Value> {
         panic!("Error occurred: {:?}", err);
     }
     if let Err(err) = result_window {
+        panic!("Error occurred: {:?}", err);
+    }
+    if let Err(err) = result_board {
         panic!("Error occurred: {:?}", err);
     }
     Json(serde_json::json!({"device": "all", "status": "on"}))

--- a/src/routes/office_routes.rs
+++ b/src/routes/office_routes.rs
@@ -12,13 +12,16 @@ pub async fn office_on_handler(_token: Token) -> Json<serde_json::Value> {
     let corner_led = OfficeDevices::corner_led();
     let table_led = OfficeDevices::table_led();
     let window_led = OfficeDevices::window_led();
-    let govee_client = GoveeClient::new(&GOVEE_API_KEY);
+    let board_led = OfficeDevices::board_led();
     let payload_corner = office_light_setup(&corner_led, "on");
     let payload_table = office_light_setup(&table_led, "on");
     let payload_window = office_light_setup(&window_led, "on");
+    let payload_board = office_light_setup(&board_led, "on");
+    let govee_client = GoveeClient::new(&GOVEE_API_KEY);
     let result_corner = govee_client.control_device(payload_corner).await;
     let result_table = govee_client.control_device(payload_table).await;
     let result_window = govee_client.control_device(payload_window).await;
+    let result_board = govee_client.control_device(payload_board).await;
     if let Err(err) = result_corner {
         panic!("Error occurred: {:?}", err);
     }
@@ -26,6 +29,9 @@ pub async fn office_on_handler(_token: Token) -> Json<serde_json::Value> {
         panic!("Error occurred: {:?}", err);
     }
     if let Err(err) = result_window {
+        panic!("Error occurred: {:?}", err);
+    }
+    if let Err(err) = result_board {
         panic!("Error occurred: {:?}", err);
     }
     Json(serde_json::json!({"device": "all", "status": "on"}))
@@ -58,7 +64,7 @@ pub async fn office_off_handler(_token: Token) -> Json<serde_json::Value> {
 
 #[get("/board/on")]
 pub async fn office_board_on_handler(_token: Token) -> Json<serde_json::Value> {
-    let board_led = OfficeDevices::corner_led();
+    let board_led = OfficeDevices::board_led();
     let payload = office_light_setup(&board_led, "on");
     let govee_client = GoveeClient::new(&GOVEE_API_KEY);
     let result = govee_client.control_device(payload).await;
@@ -70,7 +76,7 @@ pub async fn office_board_on_handler(_token: Token) -> Json<serde_json::Value> {
 
 #[get("/board/off")]
 pub async fn office_board_off_on_handler(_token: Token) -> Json<serde_json::Value> {
-    let board_led = OfficeDevices::corner_led();
+    let board_led = OfficeDevices::board_led();
     let payload = office_light_setup(&board_led, "off");
     let govee_client = GoveeClient::new(&GOVEE_API_KEY);
     let result = govee_client.control_device(payload).await;

--- a/src/routes/office_routes.rs
+++ b/src/routes/office_routes.rs
@@ -56,6 +56,30 @@ pub async fn office_off_handler(_token: Token) -> Json<serde_json::Value> {
     Json(serde_json::json!({"device": "all", "status": "on"}))
 }
 
+#[get("/board/on")]
+pub async fn office_board_on_handler(_token: Token) -> Json<serde_json::Value> {
+    let board_led = OfficeDevices::corner_led();
+    let payload = office_light_setup(&board_led, "on");
+    let govee_client = GoveeClient::new(&GOVEE_API_KEY);
+    let result = govee_client.control_device(payload).await;
+    if let Err(err) = result {
+        panic!("Error occurred: {:?}", err);
+    }
+    Json(serde_json::json!({"device": "board_led", "status": "on"}))
+}
+
+#[get("/board/off")]
+pub async fn office_board_off_on_handler(_token: Token) -> Json<serde_json::Value> {
+    let board_led = OfficeDevices::corner_led();
+    let payload = office_light_setup(&board_led, "off");
+    let govee_client = GoveeClient::new(&GOVEE_API_KEY);
+    let result = govee_client.control_device(payload).await;
+    if let Err(err) = result {
+        panic!("Error occurred: {:?}", err);
+    }
+    Json(serde_json::json!({"device": "board_led", "status": "off"}))
+}
+
 #[get("/corner/on")]
 pub async fn office_corner_on_handler(_token: Token) -> Json<serde_json::Value> {
     let corner_led = OfficeDevices::corner_led();

--- a/src/services/light_setup_service.rs
+++ b/src/services/light_setup_service.rs
@@ -20,17 +20,27 @@ pub fn tv_light_setup(command: &str) -> PayloadBody {
 }
 
 impl OfficeDevices {
+    pub fn board_led() -> Self {
+        let office_board_led_id =
+            env::var("OFFICE_BOARD_LED_ID").expect("OFFICE_BOARD_LED_ID must be set");
+        let office_board_led_model =
+            env::var("OFFICE_BOARD_LED_MODEL").expect("OFFICE_BOARD_LED_MODEL must be set");
+        let board_led = Device {
+            device_id: office_board_led_id,
+            model: office_board_led_model,
+        };
+        OfficeDevices::BoardLED(board_led)
+    }
+
     pub fn corner_led() -> Self {
         let office_corner_light_id =
             env::var("OFFICE_CORNER_LIGHT_ID").expect("OFFICE_CORNER_LIGHT_ID must be set");
         let office_corner_light_model =
             env::var("OFFICE_CORNER_LIGHT_MODEL").expect("OFFICE_CORNER_LIGHT_MODEL must be set");
-
         let corner_led = Device {
             device_id: office_corner_light_id,
             model: office_corner_light_model,
         };
-
         OfficeDevices::CornerLED(corner_led)
     }
 
@@ -39,12 +49,10 @@ impl OfficeDevices {
             env::var("OFFICE_TABLE_LED_ID").expect("OFFICE_TABLE_LED_ID must be set");
         let office_table_led_model =
             env::var("OFFICE_TABLE_LED_MODEL").expect("OFFICE_TABLE_LED_MODEL must be set");
-
         let table_led = Device {
             device_id: office_table_led_id,
             model: office_table_led_model,
         };
-
         OfficeDevices::TableLED(table_led)
     }
 
@@ -53,12 +61,10 @@ impl OfficeDevices {
             env::var("OFFICE_WINDOW_LED_ID").expect("OFFICE_WINDOW_LED_ID must be set");
         let office_window_led_model =
             env::var("OFFICE_WINDOW_LED_MODEL").expect("OFFICE_WINDOW_LED_MODEL must be set");
-
         let window_led = Device {
             device_id: office_window_led_id,
             model: office_window_led_model,
         };
-
         OfficeDevices::WindowLED(window_led)
     }
 }
@@ -69,6 +75,11 @@ pub fn office_light_setup(device: &OfficeDevices, command: &str) -> PayloadBody 
         value: command.to_string(),
     };
     match device {
+        OfficeDevices::BoardLED(board_led) => PayloadBody {
+            device: board_led.device_id.clone(),
+            model: board_led.model.clone(),
+            cmd: command,
+        },
         OfficeDevices::CornerLED(corner_led) => PayloadBody {
             device: corner_led.device_id.clone(),
             model: corner_led.model.clone(),


### PR DESCRIPTION
Introducing two new endpoints for the board light handler:

- [x] `GET /office/board/on`
- [x] `GET /office/board/off`

Tested locally and works as a charm 😃.