### PR TITLE
Use bulk_control_device method from govee-api v.1.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -454,14 +454,14 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "govee-api"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e960c715ef2d325318a438534de228c99e73a9d2213d361ff3d093115f7123"
+version = "1.2.0"
 dependencies = [
+ "futures",
  "lazy_static",
  "reqwest",
  "serde",
  "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,13 +455,14 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 [[package]]
 name = "govee-api"
 version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae8d6582c76370dea793021019f555c094dfdc5d613859efc88a72d9bde69441"
 dependencies = [
  "futures",
  "lazy_static",
  "reqwest",
  "serde",
  "serde_json",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1233,7 +1233,7 @@ dependencies = [
 
 [[package]]
 name = "rust_that_light"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "dotenv",
  "govee-api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ reqwest = {version = "0.11.20", features = ["blocking", "json"]}
 serde = {version = "1.0.188", features = ["derive"]}
 serde_json = "1.0.106"
 lazy_static = "1.4.0"
-govee-api = {version = "1.1.1"}
-# govee-api = {version = "1.1.0", path = "../../govee-api.git/handle_errors"}
+# govee-api = {version = "1.1.1"}
+govee-api = {version = "1.2.0", path = "../../govee-api.git/bulk_control_device"}
 
 [dependencies.rocket]
 version = "0.5.0-rc.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ reqwest = {version = "0.11.20", features = ["blocking", "json"]}
 serde = {version = "1.0.188", features = ["derive"]}
 serde_json = "1.0.106"
 lazy_static = "1.4.0"
-# govee-api = {version = "1.1.1"}
-govee-api = {version = "1.2.0", path = "../../govee-api.git/bulk_control_device"}
+govee-api = {version = "1.2.0"}
+# govee-api = {version = "1.2.0", path = "../../govee-api.git/bulk_control_device"}
 
 [dependencies.rocket]
 version = "0.5.0-rc.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rust_that_light"
 authors = ["Maciej Gierada @mgierada"]
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/routes/office_routes.rs
+++ b/src/routes/office_routes.rs
@@ -18,20 +18,8 @@ pub async fn office_on_handler(_token: Token) -> Json<serde_json::Value> {
     let payload_window = office_light_setup(&window_led, "on");
     let payload_board = office_light_setup(&board_led, "on");
     let govee_client = GoveeClient::new(&GOVEE_API_KEY);
-    let result_corner = govee_client.control_device(payload_corner).await;
-    let result_table = govee_client.control_device(payload_table).await;
-    let result_window = govee_client.control_device(payload_window).await;
-    let result_board = govee_client.control_device(payload_board).await;
-    if let Err(err) = result_corner {
-        panic!("Error occurred: {:?}", err);
-    }
-    if let Err(err) = result_table {
-        panic!("Error occurred: {:?}", err);
-    }
-    if let Err(err) = result_window {
-        panic!("Error occurred: {:?}", err);
-    }
-    if let Err(err) = result_board {
+    let resuts = govee_client.bulk_control_devices(vec![payload_corner, payload_table, payload_window, payload_board]).await;
+    if let Err(err) = resuts {
         panic!("Error occurred: {:?}", err);
     }
     Json(serde_json::json!({"device": "all", "status": "on"}))
@@ -49,20 +37,8 @@ pub async fn office_off_handler(_token: Token) -> Json<serde_json::Value> {
     let payload_window = office_light_setup(&window_led, "off");
     let payload_board = office_light_setup(&board_led, "off");
     let govee_client = GoveeClient::new(&GOVEE_API_KEY);
-    let result_corner = govee_client.control_device(payload_corner).await;
-    let result_table = govee_client.control_device(payload_table).await;
-    let result_window = govee_client.control_device(payload_window).await;
-    let result_board = govee_client.control_device(payload_board).await;
-    if let Err(err) = result_corner {
-        panic!("Error occurred: {:?}", err);
-    }
-    if let Err(err) = result_table {
-        panic!("Error occurred: {:?}", err);
-    }
-    if let Err(err) = result_window {
-        panic!("Error occurred: {:?}", err);
-    }
-    if let Err(err) = result_board {
+    let resuts = govee_client.bulk_control_devices(vec![payload_corner, payload_table, payload_window, payload_board]).await;
+    if let Err(err) = resuts {
         panic!("Error occurred: {:?}", err);
     }
     Json(serde_json::json!({"device": "all", "status": "on"}))

--- a/src/routes/office_routes.rs
+++ b/src/routes/office_routes.rs
@@ -18,7 +18,14 @@ pub async fn office_on_handler(_token: Token) -> Json<serde_json::Value> {
     let payload_window = office_light_setup(&window_led, "on");
     let payload_board = office_light_setup(&board_led, "on");
     let govee_client = GoveeClient::new(&GOVEE_API_KEY);
-    let resuts = govee_client.bulk_control_devices(vec![payload_corner, payload_table, payload_window, payload_board]).await;
+    let resuts = govee_client
+        .bulk_control_devices(vec![
+            payload_corner,
+            payload_table,
+            payload_window,
+            payload_board,
+        ])
+        .await;
     if let Err(err) = resuts {
         panic!("Error occurred: {:?}", err);
     }
@@ -37,7 +44,14 @@ pub async fn office_off_handler(_token: Token) -> Json<serde_json::Value> {
     let payload_window = office_light_setup(&window_led, "off");
     let payload_board = office_light_setup(&board_led, "off");
     let govee_client = GoveeClient::new(&GOVEE_API_KEY);
-    let resuts = govee_client.bulk_control_devices(vec![payload_corner, payload_table, payload_window, payload_board]).await;
+    let resuts = govee_client
+        .bulk_control_devices(vec![
+            payload_corner,
+            payload_table,
+            payload_window,
+            payload_board,
+        ])
+        .await;
     if let Err(err) = resuts {
         panic!("Error occurred: {:?}", err);
     }

--- a/src/routes/office_routes.rs
+++ b/src/routes/office_routes.rs
@@ -8,7 +8,6 @@ use crate::GOVEE_API_KEY;
 
 #[get("/on")]
 pub async fn office_on_handler(_token: Token) -> Json<serde_json::Value> {
-    // TODO Refactor this ugly implementation when bulk control is available
     let corner_led = OfficeDevices::corner_led();
     let table_led = OfficeDevices::table_led();
     let window_led = OfficeDevices::window_led();
@@ -34,7 +33,6 @@ pub async fn office_on_handler(_token: Token) -> Json<serde_json::Value> {
 
 #[get("/off")]
 pub async fn office_off_handler(_token: Token) -> Json<serde_json::Value> {
-    // TODO Refactor this ugly implementation when bulk control is available
     let corner_led = OfficeDevices::corner_led();
     let table_led = OfficeDevices::table_led();
     let window_led = OfficeDevices::window_led();


### PR DESCRIPTION
Refactor `office_on_handler` and `office_off_handler` to use a `bulk_control_device` method from the latest `govee_api` library v.1.2.0.