### PR TITLE
Fix breaking changes in rocket 0.5.0-rc.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1233,7 +1233,7 @@ dependencies = [
 
 [[package]]
 name = "rust_that_light"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "dotenv",
  "govee-api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rust_that_light"
 authors = ["Maciej Gierada @mgierada"]
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/implementations/access_token.rs
+++ b/src/implementations/access_token.rs
@@ -16,7 +16,7 @@ impl<'r> FromRequest<'r> for Token {
             if auth_token == ACCESS_TOKEN.to_string() {
                 Outcome::Success(Token(auth_token.to_string()))
             } else {
-                Outcome::Failure((
+                Outcome::Error((
                     Status::Unauthorized,
                     AuthError {
                         error: "Invalid Authorization token".to_string(),
@@ -24,7 +24,7 @@ impl<'r> FromRequest<'r> for Token {
                 ))
             }
         } else {
-            Outcome::Failure((
+            Outcome::Error((
                 Status::Unauthorized,
                 AuthError {
                     error: "Missing Authorization header".to_string(),


### PR DESCRIPTION
In the latest release of `rocket` which is `0.5.0-rc.4` there is a breaking change. `Outcome::Failure` is renamed to `Outcome::Error`.